### PR TITLE
Added require prop-types

### DIFF
--- a/src/react-copy-button-wrapper.js
+++ b/src/react-copy-button-wrapper.js
@@ -10,6 +10,7 @@ const React = require('react')
 const ReactZeroClipboard = require('react-zeroclipboard')
 const select = require('select')
 const browser = require('bowser')
+const PropTypes = require('prop-types')
 
 class ReactCopyButtonWrapper extends React.Component {
   constructor (props) {


### PR DESCRIPTION
Hey, this is to resolve the following issue 

```
ReferenceError: PropTypes is not defined
(anonymous function)
node_modules/react-copy-button-wrapper/dist/react-copy-button-wrapper.js:159
  156 | 
  157 | ReactCopyButtonWrapper.displayName = 'ReactCopyButtonWrapper';
  158 | ReactCopyButtonWrapper.propTypes = {
> 159 |   text: PropTypes.string,
  160 |   html: PropTypes.string,
  161 |   selector: PropTypes.string,
  162 |   domElement: PropTypes.object,
```